### PR TITLE
Configurable number of products for categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Fabrizio Balliano
 [http://fabrizioballiano.com](http://fabrizioballiano.com)  
 [@fballiano](https://twitter.com/fballiano)
 
+Maurizio Brioschi @ [Mothership](http://www.mothership.de)
+
 Licence
 -------
 [OSL - Open Software Licence 3.0](http://opensource.org/licenses/osl-3.0.php)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Magento Hide Empty Categories
 =============================
 
-Removes categories with no products when loading a categories collection
+Removes categories with less than the number of products, configurable from the control panel
 
 Backup!!!
 ---------

--- a/app/code/community/Fballiano/HideEmptyCategories/Helper/Data.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Helper/Data.php
@@ -17,6 +17,7 @@
  *
  * @category   FBalliano
  * @package    Fballiano_HideEmptyCategories
+ * @author Maurizio Brioschi<brioschi@mothership.de>
  * @copyright  Copyright (c) 2014 Fabrizio Balliano (http://fabrizioballiano.it)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/app/code/community/Fballiano/HideEmptyCategories/Helper/Data.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Helper/Data.php
@@ -23,31 +23,7 @@
 class Fballiano_HideEmptyCategories_Helper_Data extends Mage_Core_Helper_Abstract
 {
     /**
-     * Get categories_id and number of sellable products having less than $minimumItemsNumber
-     * @param int $minimumItemsNumber
-     * @param Mage_Catalog_Model_Category $category to filter for
-     * @return array representing category_id and numbers of products
-     */
-    public function getNotSellableCategories($minimumItemsNumber = 1, $category = null)
-    {
-        $query = "select ccp.category_id,count(csi.product_id) as products_count from `catalog_product_super_link` cpsl
-                    JOIN catalog_category_product ccp ON cpsl.`parent_id`=ccp.product_id
-                    JOIN cataloginventory_stock_item csi ON csi.`product_id` = cpsl.product_id";
-        if (!is_null($category)) {
-            $query .= " WHERE ccp.category_id=" . $category->getEntityId();
-        }
-
-        $query .= " GROUP BY ccp.category_id HAVING products_count<" . $minimumItemsNumber;
-
-        $resource = Mage::getSingleton('core/resource');
-        $readConnection = $resource->getConnection('core_read');
-        $results = $readConnection->fetchAll($query);
-
-        return $results;
-    }
-
-    /**
-     * Return true if category has products
+     * Check if a $category has the $minimum sellable items
      * @param $category_id
      * @param int $minimumItemsNumber
      * @return bool
@@ -63,7 +39,7 @@ class Fballiano_HideEmptyCategories_Helper_Data extends Mage_Core_Helper_Abstrac
         // Add filter to exclude products that are not on stock
         Mage::getModel('cataloginventory/stock_status')->addIsInStockFilterToCollection($products);
 
-        return ($products->count() > $minimumItemsNumber) ? true : false;
+        return ($products->count() >= $minimumItemsNumber);
 
     }
 }

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
@@ -32,12 +32,7 @@ class Fballiano_HideEmptyCategories_Model_Catalog_Resource_Category_Flat extends
 
         $minimum_items = Mage::getStoreConfig('hideemptycategories_options/hideemptycategories_group/hideemptycategories_input', Mage::app()->getStore());
 
-        //retrieve sellable products foreach category
         $helper = new Fballiano_HideEmptyCategories_Helper_Data();
-        $categories_products = $helper->getNotSellableCategories($minimum_items);
-        $categories_to_hide = array_map(function ($v, $k) {
-            return $v['category_id'];
-        }, $categories_products, array_keys($categories_products));
         foreach ($nodes as $node) {
             if ($node->getDisplayMode() == "PAGE") continue;
             $children = $node->getChildren();
@@ -47,6 +42,7 @@ class Fballiano_HideEmptyCategories_Model_Catalog_Resource_Category_Flat extends
                 foreach ($subcategories as $cat) {
                     if (!$helper->_hasProducts($cat)) {
                         unset($nodes[$cat]);
+                        $count_subcategories = $count_subcategories - 1;
                     }
                 }
 
@@ -56,12 +52,7 @@ class Fballiano_HideEmptyCategories_Model_Catalog_Resource_Category_Flat extends
                 continue;
             }
 
-            if (in_array($node->getId(), $categories_to_hide)) {
-                unset($nodes[$node->getId()]);
-                continue;
-            }
-
-            if (!$helper->_hasProducts($node->getId())) {
+            if (!$helper->_hasProducts($node->getId(), $minimum_items)) {
                 unset($nodes[$node->getId()]);
             }
         }

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
@@ -30,16 +30,18 @@ class Fballiano_HideEmptyCategories_Model_Catalog_Resource_Category_Flat extends
         $category_collection = Mage::getResourceModel('catalog/category_collection');
         $category_collection->loadProductCount($nodes, true, true);
 
-        $minimum_items = Mage::getStoreConfig('hideemptycategories_options/hideemptycategories_group/hideemptycategories_input',Mage::app()->getStore());
+        $minimum_items = Mage::getStoreConfig('hideemptycategories_options/hideemptycategories_group/hideemptycategories_input', Mage::app()->getStore());
 
         //retrieve sellable products foreach category
         $helper = new Fballiano_HideEmptyCategories_Helper_Data();
         $categories_products = $helper->getNotSellableCategories($minimum_items);
-        $categories_to_hide = array_map(function ($v, $k) { return $v['category_id']; }, $categories_products, array_keys($categories_products));
+        $categories_to_hide = array_map(function ($v, $k) {
+            return $v['category_id'];
+        }, $categories_products, array_keys($categories_products));
         foreach ($nodes as $node) {
             if ($node->getDisplayMode() == "PAGE") continue;
             if (strlen($node->getChildren()) > 0) continue;
-            if (in_array($node->getId(),$categories_to_hide)) {
+            if (in_array($node->getId(), $categories_to_hide)) {
                 unset($nodes[$node->getId()]);
             }
         }

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
@@ -30,9 +30,11 @@ class Fballiano_HideEmptyCategories_Model_Catalog_Resource_Category_Flat extends
         $category_collection = Mage::getResourceModel('catalog/category_collection');
         $category_collection->loadProductCount($nodes, true, true);
 
+        $minimum_items = Mage::getStoreConfig('hideemptycategories_options/hideemptycategories_group/hideemptycategories_input',Mage::app()->getStore());
+
         //retrieve sellable products foreach category
         $helper = new Fballiano_HideEmptyCategories_Helper_Data();
-        $categories_products = $helper->getNotSellableCategories(6);
+        $categories_products = $helper->getNotSellableCategories($minimum_items);
         $categories_to_hide = array_map(function ($v, $k) { return $v['category_id']; }, $categories_products, array_keys($categories_products));
         foreach ($nodes as $node) {
             if ($node->getDisplayMode() == "PAGE") continue;

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
@@ -40,8 +40,28 @@ class Fballiano_HideEmptyCategories_Model_Catalog_Resource_Category_Flat extends
         }, $categories_products, array_keys($categories_products));
         foreach ($nodes as $node) {
             if ($node->getDisplayMode() == "PAGE") continue;
-            if (strlen($node->getChildren()) > 0) continue;
+            $children = $node->getChildren();
+            if (strlen($children) > 0) {
+                $subcategories = explode(",", $children);
+                $count_subcategories = count($subcategories);
+                foreach ($subcategories as $cat) {
+                    if (!$helper->_hasProducts($cat)) {
+                        unset($nodes[$cat]);
+                    }
+                }
+
+                if ($count_subcategories == 0) {
+                    unset($nodes[$node->getId()]);
+                }
+                continue;
+            }
+
             if (in_array($node->getId(), $categories_to_hide)) {
+                unset($nodes[$node->getId()]);
+                continue;
+            }
+
+            if (!$helper->_hasProducts($node->getId())) {
                 unset($nodes[$node->getId()]);
             }
         }

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Catalog/Resource/Category/Flat.php
@@ -17,6 +17,7 @@
  *
  * @category   FBalliano
  * @package    Fballiano_HideEmptyCategories
+ * @author Maurizio Brioschi<brioschi@mothership.de>
  * @copyright  Copyright (c) 2014 Fabrizio Balliano (http://fabrizioballiano.it)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FBalliano
  *
@@ -19,7 +20,6 @@
  * @copyright  Copyright (c) 2014 Fabrizio Balliano (http://fabrizioballiano.it)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-
 class Fballiano_HideEmptyCategories_Model_Observer extends Mage_Core_Model_Abstract
 {
     public function catalogCategoryFlatLoadnodesBefore(Varien_Event_Observer $observer)
@@ -47,17 +47,19 @@ class Fballiano_HideEmptyCategories_Model_Observer extends Mage_Core_Model_Abstr
      */
     protected function _removeHiddenCollectionItems($collection)
     {
-        $minimum_items = Mage::getStoreConfig('hideemptycategories_options/hideemptycategories_group/hideemptycategories_input',Mage::app()->getStore());
+        $minimum_items = Mage::getStoreConfig('hideemptycategories_options/hideemptycategories_group/hideemptycategories_input', Mage::app()->getStore());
         $helper = new Fballiano_HideEmptyCategories_Helper_Data();
         $categories_products = $helper->getNotSellableCategories($minimum_items);
-        $categories_to_hide = array_map(function ($v, $k) { return $v['category_id']; }, $categories_products, array_keys($categories_products));
+        $categories_to_hide = array_map(function ($v, $k) {
+            return $v['category_id'];
+        }, $categories_products, array_keys($categories_products));
         // Loop through each category or product
         foreach ($collection as $key => $item) {
             // If it is a category
             if ($item->getEntityTypeId() == 3) {
                 if ($item->getDisplayMode() == "PAGE") continue;
                 if (strlen($item->getChildren()) > 0) continue;
-                if (in_array($key,$categories_to_hide)) {
+                if (in_array($key, $categories_to_hide)) {
                     $collection->removeItemByKey($key);
                 }
 

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
@@ -20,30 +20,31 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Fballiano_HideEmptyCategories_Model_Observer
+class Fballiano_HideEmptyCategories_Model_Observer extends Mage_Core_Model_Abstract
 {
-    public function catalogCategoryFlatLoadnodesBefore(Varien_Event_Observer $observer)
-    {
-        $select = $observer->getEvent()->getSelect();
-        $select->columns("display_mode");
-    }
-
-    public function catalogCategoryCollectionLoadBefore(Varien_Event_Observer $observer)
-    {
-        $collection = $observer->getEvent()->getCategoryCollection();
-        $collection->addAttributeToSelect("display_mode");
-        $collection->addAttributeToSelect("is_anchor");
-    }
 
     public function catalogCategoryCollectionLoadAfter(Varien_Event_Observer $observer)
     {
-        $collection = $observer->getEvent()->getCategoryCollection();
-        $collection->loadProductCount($collection->getItems(), true, true);
+        $this->_removeHiddenCollectionItems($observer->getEvent()->getCategoryCollection());
+    }
+
+    /**
+     * Remove hidden items from a product or category collection
+     *
+     * @param Mage_Eav_Model_Entity_Collection_Abstract|Mage_Core_Model_Mysql4_Collection_Abstract $collection
+     */
+    protected function _removeHiddenCollectionItems($collection)
+    {
+        // Loop through each category or product
         foreach ($collection as $key => $item) {
+            // If it is a category
             if ($item->getEntityTypeId() == 3) {
                 if ($item->getDisplayMode() == "PAGE") continue;
                 if ($item->getProductCount()) continue;
-                $collection->removeItemByKey($key);
+                if (count($item->getChildren()) > 0) continue;
+                if ($item->getProductCount() < 4) {
+                    $collection->removeItemByKey($key);
+                }
             }
         }
     }

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
@@ -49,20 +49,16 @@ class Fballiano_HideEmptyCategories_Model_Observer extends Mage_Core_Model_Abstr
     {
         $minimum_items = Mage::getStoreConfig('hideemptycategories_options/hideemptycategories_group/hideemptycategories_input', Mage::app()->getStore());
         $helper = new Fballiano_HideEmptyCategories_Helper_Data();
-        $categories_products = $helper->getNotSellableCategories($minimum_items);
-        $categories_to_hide = array_map(function ($v, $k) {
-            return $v['category_id'];
-        }, $categories_products, array_keys($categories_products));
+
         // Loop through each category or product
         foreach ($collection as $key => $item) {
             // If it is a category
             if ($item->getEntityTypeId() == 3) {
                 if ($item->getDisplayMode() == "PAGE") continue;
                 if (strlen($item->getChildren()) > 0) continue;
-                if (in_array($key, $categories_to_hide)) {
+                if (!$helper->_hasProducts($item->getId(), $minimum_items)) {
                     $collection->removeItemByKey($key);
                 }
-
             }
         }
     }

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
@@ -17,6 +17,7 @@
  *
  * @category   FBalliano
  * @package    Fballiano_HideEmptyCategories
+ * @author Maurizio Brioschi<brioschi@mothership.de>
  * @copyright  Copyright (c) 2014 Fabrizio Balliano (http://fabrizioballiano.it)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
+++ b/app/code/community/Fballiano/HideEmptyCategories/Model/Observer.php
@@ -47,8 +47,9 @@ class Fballiano_HideEmptyCategories_Model_Observer extends Mage_Core_Model_Abstr
      */
     protected function _removeHiddenCollectionItems($collection)
     {
+        $minimum_items = Mage::getStoreConfig('hideemptycategories_options/hideemptycategories_group/hideemptycategories_input',Mage::app()->getStore());
         $helper = new Fballiano_HideEmptyCategories_Helper_Data();
-        $categories_products = $helper->getNotSellableCategories(4);
+        $categories_products = $helper->getNotSellableCategories($minimum_items);
         $categories_to_hide = array_map(function ($v, $k) { return $v['category_id']; }, $categories_products, array_keys($categories_products));
         // Loop through each category or product
         foreach ($collection as $key => $item) {

--- a/app/code/community/Fballiano/HideEmptyCategories/etc/config.xml
+++ b/app/code/community/Fballiano/HideEmptyCategories/etc/config.xml
@@ -77,4 +77,11 @@
             </resources>
         </acl>
     </adminhtml>
+    <default>
+        <hideemptycategories_options>
+            <hideemptycategories_group>
+                <hideemptycategories_input>4</hideemptycategories_input>
+            </hideemptycategories_group>
+        </hideemptycategories_options>
+    </default>
 </config>

--- a/app/code/community/Fballiano/HideEmptyCategories/etc/config.xml
+++ b/app/code/community/Fballiano/HideEmptyCategories/etc/config.xml
@@ -53,4 +53,28 @@
             </catalog_category_collection_load_after>
         </events>
     </frontend>
+    <adminhtml>
+        <acl>
+            <resources>
+                <all>
+                    <title>Allow Everything</title>
+                </all>
+                <admin>
+                    <children>
+                        <system>
+                            <children>
+                                <config>
+                                    <children>
+                                        <hideemptycategories_options>
+                                            <title>Mothership</title>
+                                        </hideemptycategories_options>
+                                    </children>
+                                </config>
+                            </children>
+                        </system>
+                    </children>
+                </admin>
+            </resources>
+        </acl>
+    </adminhtml>
 </config>

--- a/app/code/community/Fballiano/HideEmptyCategories/etc/system.xml
+++ b/app/code/community/Fballiano/HideEmptyCategories/etc/system.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <tabs>
+        <magento-hide-empty-categories translate="label" module="hideemptycategories">
+            <label>Hide Empty Categories</label>
+            <sort_order>100</sort_order>
+        </magento-hide-empty-categories>
+    </tabs>
+    <sections>
+        <hideemptycategories_options translate="label" module="hideemptycategories">
+            <label>Extension Options</label>
+            <tab>magento-hide-empty-categories</tab>
+            <sort_order>1000</sort_order>
+            <show_in_default>1</show_in_default>
+            <show_in_website>1</show_in_website>
+            <show_in_store>1</show_in_store>
+
+            <groups>
+                <hideemptycategories_group translate="label" module="hideemptycategories">
+                    <label>Options</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>1000</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+
+                    <fields>
+                        <hideemptycategories_input translate="label">
+                            <label>Minimum products for category: </label>
+                            <comment>Minimum products number to not hide a category</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </hideemptycategories_input>
+                    </fields>
+                </hideemptycategories_group>
+            </groups>
+        </hideemptycategories_options>
+    </sections>
+</config>

--- a/app/code/community/Fballiano/HideEmptyCategories/etc/system.xml
+++ b/app/code/community/Fballiano/HideEmptyCategories/etc/system.xml
@@ -26,7 +26,7 @@
 
                     <fields>
                         <hideemptycategories_input translate="label">
-                            <label>Minimum products for category: </label>
+                            <label>Minimum products for category:</label>
                             <comment>Minimum products number to not hide a category</comment>
                             <frontend_type>text</frontend_type>
                             <sort_order>20</sort_order>


### PR DESCRIPTION
Hide categories that have less than a number of products.

This number is configurable like an extension from the backend: it's possible to configure it to zero to hide completely empty categories
